### PR TITLE
Bump govuk_elements to new custom radios / checkboxes

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "express": "4.13.3",
     "express-nunjucks": "^0.9.3",
     "express-writer": "0.0.4",
-    "govuk-elements-sass": "alphagov/govuk_elements#v2.0.0",
+    "govuk-elements-sass": "alphagov/govuk_elements#45f270c35f9ce04e6a99246c50aac28712469f35",
     "govuk_frontend_toolkit": "^4.18.1",
     "govuk_template_mustache": "^0.18.1",
     "grunt": "0.4.5",


### PR DESCRIPTION
Set package.json to track the latest version of the custom-radios. This, along with the latest govuk_frontend_toolkit, means that the ‘Checkboxes (group)’ and ‘Radio buttons’ examples will show the proposed new styles ready for testing with assistive tech.

So far I’ve only tested VoiceOver with these - they work the same way as the previous elements block labels. On a similar style on Verify we had problems with Jaws-on-IE, but that was down to the use of extra elements to build the radio buttons and here we’re using pseudo elements.

The custom radio buttons work is being tracked in https://github.com/alphagov/govuk_elements/pull/296
