### PR TITLE
Bump govuk_frontend_toolkit to 4.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express-nunjucks": "^0.9.3",
     "express-writer": "0.0.4",
     "govuk-elements-sass": "alphagov/govuk_elements#v1.1.1",
-    "govuk_frontend_toolkit": "^4.6.0",
+    "govuk_frontend_toolkit": "^4.18.0",
     "govuk_template_mustache": "^0.16.0",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",


### PR DESCRIPTION
This PR updates the govuk frontend toolkit to the latest version 4.18.0, this includes the following changes:

https://github.com/alphagov/govuk_frontend_toolkit/blob/master/CHANGELOG
.md
#4.18.0
- Add GOVUK.ShowHideContent JavaScript to support showing and hiding
  content, toggled by radio buttons and checkboxes ([PR
  #315](https://github.com/alphagov/govuk_frontend_toolkit/pull/315)).
#4.17.0
- SelectionButtons will add a class to the label with the type of the
  child input ([PR
  #317](https://github.com/alphagov/govuk_frontend_toolkit/pull/317))
#4.16.1
- Fix anchor-buttons.js to trigger a native click event, also rename to
  shimLinksWithButtonRole.js to explain what it does
- Add tests for shimLinksWithButtonRole ([PR
  #310](https://github.com/alphagov/govuk_frontend_toolkit/pull/310))
#4.16.0
- Add Department for International Trade organisation ([PR
  #308](https://github.com/alphagov/govuk_frontend_toolkit/pull/308))
#4.15.0
- Add support for Google Analytics fieldsObject ([PR
  #298](https://github.com/alphagov/govuk_frontend_toolkit/pull/298))
- anchor-buttons.js: normalise keyboard behaviour between buttons and
  links with a button role ([PR
  #297](https://github.com/alphagov/govuk_frontend_toolkit/pull/297))
#4.14.1
- Fix tabular number sizing in Firefox ([PR
  #301](https://github.com/alphagov/govuk_frontend_toolkit/pull/301))
#4.14.0
- Allow use of multiple GA customDimensionIndex. See [this
  section](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/
  docs/javascript.md#using-google-custom-dimensions-with-your-own-statisti
  cal-model) of the documentation for more information.
- Configurable duration (in days) for AB Test cookie. See [this
  section](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/
  docs/javascript.md#multivariate-test-framework) of the documentation
  for more information.
- Allow base scripts to run within a module loader. See [this
  PR](https://github.com/alphagov/govuk_frontend_toolkit/pull/290) for
  more information.
#4.13.0
- Make headings block-level by default (PR #200). If you are styling
  elements you want to be inline with heading includes, you’ll need to
  explicitly make them inline in your CSS.
#4.12.0
- Increase button padding to match padding from GOV.UK elements (PR
  #275).
  If you have UI which depends on the padding set by the button mixin in
  the frontend toolkit and this is not overridden by button padding set
  by GOV.UK elements, this change will affect it.
#4.11.0
- Remove the GDS-Logo font-face definition (PR #272)
- Move the @viewport statements to govuk_template (PR #272). If you
  upgrade to this version of govuk_frontend_toolkit and you’re also using
  govuk_template you’ll need to upgrade that to at least 0.17.2 to
  maintain compatibility with desktop IE10 in snap mode.
#4.10.0
- Allow New Transport font stack to be overridden by apps using
  `$toolkit-font-stack`
  and `$toolkit-font-stack-tabular` (PR #230)
#4.9.1
- Fix phase banner alignment (PR #266)
#4.9.0
- Add websafe organisation colours
- Split colours into two files with backwards-compatible colours.scss
  replacement
#4.8.2
- Add GOV.UK lint to lint scss files (PR #260)
- Remove reference to old colour palette (PR #256)
- Fix link to GOV.UK elements - tabular data
#4.8.1
- Update DEFRA brand colour to new green (PR #249)
#4.8.0
- Pass cohort name to analytics when using multivariate test (PR #251)
#4.7.0
- Add 'mailto' tracking to GOV.UK Analytics (PR #244)
#4.6.1
- Use the Sass variable $light-blue for link active and hover colours
  (PR #242)
