### PR TITLE
Update govuk template mustache to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "express-writer": "0.0.4",
     "govuk-elements-sass": "alphagov/govuk_elements#v1.1.1",
     "govuk_frontend_toolkit": "^4.18.0",
-    "govuk_template_mustache": "^0.16.0",
+    "govuk_template_mustache": "^0.18.1",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
     "grunt-concurrent": "0.4.3",


### PR DESCRIPTION
https://raw.githubusercontent.com/alphagov/govuk_template/master/CHANGEL
OG.md
#0.18.1
- Remove gov.uk prefix from relative links when printing ([PR
  #234](https://github.com/alphagov/govuk_template/pull/234))
- Fix a `.visually-hidden` bug on GOV.UK ([PR
  #177](https://github.com/alphagov/govuk_template/pull/177))
#0.18.0
- Publish the Jinja version of the template to NPM
- Update HTML5 Shiv to the latest version
- Remove an errant font loader script that was only being used for IE8
#0.17.3
- Fix colour of H2 headings in footer
#0.17.2
- Fix a bug with the skip-to-content link and iOS Voiceover
- Migrate @viewport statement from govuk_frontend_toolkit
#0.17.1
- Reduce file size of template: removes HTML comments, `type`
  attributes on
  scripts, and uses HTML5 charset declaration. #208
- Switch external link media query to be mobile first #205
- Sass file cleanups
  - Replace old grid mixins with newer grid from frontend toolkit #134
  - Remove duplicate grey variables #201
#0.17.0
- Add CSS hook (`.js-hidden`) for hiding content when JS is enabled.
  Some apps
  have an equivalent hook, which can be removed once upgraded to this
  version
#0.16.4
- Fix publish the Jinja version of the template with a `package.json`
  for those
  consuming it with NPM
#0.16.3
- make the Django version of the template into a proper Python package
- publish the Jinja version of the template with a `package.json` for
  those
  consuming it with NPM
#0.16.2
- more static assets added to `assets.precompile` to improve
  compatibility with apps running rails > 4.2.5
#0.16.1
- Fix colour of logo when in `:active` state
